### PR TITLE
ios statusbarの色変更

### DIFF
--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -5,7 +5,7 @@ struct iOSApp: App {
 	var body: some Scene {
 		WindowGroup {
 		    ZStack {
-		        Color.white.ignoresSafeArea(.all) // status bar color
+		        Color.blue.ignoresSafeArea(.all) // status bar color
 			    ContentView()
 			}.preferredColorScheme(.light)
 		}


### PR DESCRIPTION
# 修正内容
swiftuiのステータスバーと画面の背景色を合わせる変更。

swiftuiとcomposeのデフォルトのColorの色味が若干違うので、RGB値を合わせたら色の統一ができた。

# ios 
<img src="https://github.com/LeoAndo/compose-multiplatform-ios-android-template/assets/16476224/06a17d9d-f038-4002-b4c4-34e8e9033259" width=320 />

# refs
https://developer.apple.com/documentation/swiftui/color