### PR TITLE
ios statusbarと画面の背景色を合わせる対応

### DIFF
--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -5,8 +5,8 @@ struct iOSApp: App {
 	var body: some Scene {
 		WindowGroup {
 		    ZStack {
-                let skyBlue = Color(red: 0.4627, green: 0.8392, blue: 1.0)
-                skyBlue.ignoresSafeArea(.all) // status bar color
+                            let skyBlue = Color(red: 0.4627, green: 0.8392, blue: 1.0)
+                            skyBlue.ignoresSafeArea(.all) // status bar color
 			    ContentView()
 			}.preferredColorScheme(.light)
 		}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -5,7 +5,8 @@ struct iOSApp: App {
 	var body: some Scene {
 		WindowGroup {
 		    ZStack {
-		        Color.blue.ignoresSafeArea(.all) // status bar color
+                let skyBlue = Color(red: 0.4627, green: 0.8392, blue: 1.0)
+                skyBlue.ignoresSafeArea(.all) // status bar color
 			    ContentView()
 			}.preferredColorScheme(.light)
 		}

--- a/shared/src/commonMain/kotlin/App.kt
+++ b/shared/src/commonMain/kotlin/App.kt
@@ -24,8 +24,10 @@ fun App() {
     MaterialTheme {
         var greetingText by remember { mutableStateOf("Hello, World!") }
         var showImage by remember { mutableStateOf(false) }
+
+        val skyBlue = Color.Blue.copy(red = 0.4627f, green = 0.8392f, blue = 1.0f)
         Column(
-            Modifier.fillMaxSize().background(Color.Blue),
+            Modifier.fillMaxSize().background(skyBlue),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Button(onClick = {

--- a/shared/src/commonMain/kotlin/App.kt
+++ b/shared/src/commonMain/kotlin/App.kt
@@ -2,6 +2,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
@@ -13,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 
@@ -22,7 +24,10 @@ fun App() {
     MaterialTheme {
         var greetingText by remember { mutableStateOf("Hello, World!") }
         var showImage by remember { mutableStateOf(false) }
-        Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            Modifier.fillMaxSize().background(Color.Blue),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
             Button(onClick = {
                 greetingText = "Hello, ${getPlatformName()}"
                 showImage = !showImage


### PR DESCRIPTION
# 修正内容
swiftuiのステータスバーと画面の背景色を合わせる変更。

swiftuiとcomposeのデフォルトColorの色味が若干違うので、RGB値を合わせたら色の統一ができた。

# ios 
<img src="https://github.com/LeoAndo/compose-multiplatform-ios-android-template/assets/16476224/06a17d9d-f038-4002-b4c4-34e8e9033259" width=320 />

# refs
https://developer.apple.com/documentation/swiftui/color